### PR TITLE
Modernize technology-icons webfont gem (1.0.0)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [ main, master, modernize ]
+    branches: [ main, master ]
   pull_request:
-    branches: [ main, master, modernize ]
+    branches: [ main, master ]
 
 jobs:
   test:
@@ -30,16 +30,16 @@ jobs:
       uses: ruby/setup-ruby@v1
       with:
         ruby-version: ${{ matrix.ruby }}
+        bundler: '2.6'
         bundler-cache: true
 
     - name: Run tests
       run: bundle exec rake
 
-    - name: Run RuboCop
-      run: bundle exec rubocop
-
-  security:
+  lint:
     runs-on: ubuntu-latest
+    env:
+      RAILS_VERSION: '8.0'
 
     steps:
     - uses: actions/checkout@v4
@@ -48,6 +48,25 @@ jobs:
       uses: ruby/setup-ruby@v1
       with:
         ruby-version: '3.3'
+        bundler: '2.6'
+        bundler-cache: true
+
+    - name: Run RuboCop
+      run: bundle exec rubocop
+
+  security:
+    runs-on: ubuntu-latest
+    env:
+      RAILS_VERSION: '8.1'
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Set up Ruby
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: '3.3'
+        bundler: '2.6'
         bundler-cache: true
 
     - name: Security audit

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,8 @@ jobs:
             rails: '7.2'
           - ruby: '3.0'
             rails: '8.0'
+          - ruby: '3.1'
+            rails: '8.0'
 
     env:
       RAILS_VERSION: ${{ matrix.rails }}
@@ -30,7 +32,7 @@ jobs:
       uses: ruby/setup-ruby@v1
       with:
         ruby-version: ${{ matrix.ruby }}
-        bundler: '2.6'
+        bundler: '2.4.22'
         bundler-cache: true
 
     - name: Run tests
@@ -48,7 +50,7 @@ jobs:
       uses: ruby/setup-ruby@v1
       with:
         ruby-version: '3.3'
-        bundler: '2.6'
+        bundler: '2.4.22'
         bundler-cache: true
 
     - name: Run RuboCop
@@ -66,7 +68,7 @@ jobs:
       uses: ruby/setup-ruby@v1
       with:
         ruby-version: '3.3'
-        bundler: '2.6'
+        bundler: '2.4.22'
         bundler-cache: true
 
     - name: Security audit

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,54 @@
+name: CI
+
+on:
+  push:
+    branches: [ main, master, modernize ]
+  pull_request:
+    branches: [ main, master, modernize ]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        ruby: ['3.0', '3.1', '3.2', '3.3']
+        rails: ['6.0', '6.1', '7.0', '7.1', '7.2', '8.0']
+        exclude:
+          - ruby: '3.0'
+            rails: '7.2'
+          - ruby: '3.0'
+            rails: '8.0'
+
+    env:
+      RAILS_VERSION: ${{ matrix.rails }}
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Set up Ruby
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: ${{ matrix.ruby }}
+        bundler-cache: true
+
+    - name: Run tests
+      run: bundle exec rake
+
+    - name: Run RuboCop
+      run: bundle exec rubocop
+
+  security:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Set up Ruby
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: '3.3'
+        bundler-cache: true
+
+    - name: Security audit
+      run: bundle exec bundle-audit --update

--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,38 @@
+## Ruby/Bundler
 /.bundle/
-/.yardoc
+/vendor/bundle/
 /Gemfile.lock
+
+## Documentation
+/.yardoc/
 /_yardoc/
-/coverage/
 /doc/
-/pkg/
+/rdoc/
+
+## Testing
+/coverage/
 /spec/reports/
+/test/tmp/
+/test/version_tmp/
+
+## Build artifacts
+/pkg/
 /tmp/
+*.gem
+
+## IDE and OS files
+.DS_Store
+.idea/
+.vscode/
+*.swp
+*.swo
+*~
+.ruby-version
+.ruby-gemset
+
+## Environment
+.env
+.env.local
+
+## Logs
+npm-debug.log

--- a/.rspec
+++ b/.rspec
@@ -1,0 +1,1 @@
+--require spec_helper

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,34 @@
+AllCops:
+  TargetRubyVersion: 3.0
+  NewCops: enable
+  SuggestExtensions: false
+  Exclude:
+    - 'vendor/**/*'
+    - 'bin/**/*'
+
+Style/Documentation:
+  Enabled: false
+
+Style/StringLiterals:
+  Enabled: true
+  EnforcedStyle: double_quotes
+
+Style/FrozenStringLiteralComment:
+  Enabled: true
+  EnforcedStyle: always
+
+Layout/LineLength:
+  Max: 120
+  Exclude:
+    - '*.gemspec'
+
+Metrics/BlockLength:
+  Exclude:
+    - 'spec/**/*'
+    - '*.gemspec'
+
+Gemspec/DevelopmentDependencies:
+  Enabled: false
+
+Gemspec/AddRuntimeDependency:
+  Enabled: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,0 @@
-language: ruby
-rvm:
-  - 1.9.3
-  - 2.0.0
-  - 2.1.4
-  - 2.1.5
-  - 2.2.1
-before_install: gem install bundler -v 1.10.6

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,34 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+## [1.0.0] - 2026-05-30
+
+### Breaking Changes
+
+- Minimum Ruby version increased to 3.0
+- Minimum Rails version increased to 6.0
+
+### Added
+
+- Explicit `railties` runtime dependency (>= 6.0, < 9.0)
+- GitHub Actions CI with Ruby and Rails matrix
+- RuboCop configuration and linting in CI
+- bundler-audit security scanning in CI
+- RSpec test suite
+- CHANGELOG and UPGRADE_GUIDE
+- Expanded gemspec metadata and MFA requirement
+
+### Changed
+
+- Modernized gemspec and development dependencies
+- Updated README with Requirements and modern asset pipeline notes
+- Removed Travis CI
+
+## [0.1.2] - Previous Release
+
+- Technology icon webfont packaged as a Rails engine
+
+---
+
+For upgrade instructions, see [UPGRADE_GUIDE.md](UPGRADE_GUIDE.md)

--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,9 @@
-source 'https://rubygems.org'
+# frozen_string_literal: true
 
-# Specify your gem's dependencies in technology-icons.gemspec
+source "https://rubygems.org"
+
 gemspec
+
+if (rails_version = ENV.fetch("RAILS_VERSION", nil))
+  gem "railties", "~> #{rails_version}.0"
+end

--- a/README.md
+++ b/README.md
@@ -1,11 +1,14 @@
 # Technology::Icons
 
-[![Build Status](https://travis-ci.org/ethirajsrinivasan/technology-icons.svg?branch=master)](https://travis-ci.org/ethirajsrinivasan/technology-icons)
-[![Code Climate](https://codeclimate.com/github/ethirajsrinivasan/technology-icons/badges/gpa.svg)](https://codeclimate.com/github/ethirajsrinivasan/technology-icons)
-[![security](https://hakiri.io/github/ethirajsrinivasan/technology-icons/master.svg)](https://hakiri.io/github/ethirajsrinivasan/technology-icons/master)
+[![CI](https://github.com/ethirajsrinivasan/technology-icons/actions/workflows/ci.yml/badge.svg)](https://github.com/ethirajsrinivasan/technology-icons/actions/workflows/ci.yml)
+[![Gem Version](https://badge.fury.io/rb/technology-icons.svg)](https://badge.fury.io/rb/technology-icons)
 
+Technology icon webfont for Rails applications.
 
-technology-icons is a webfont gem which includes many technology icons to be included in your rails application
+## Requirements
+
+- Ruby >= 3.0
+- Rails >= 6.0
 
 ## Installation
 
@@ -17,34 +20,46 @@ gem 'technology-icons'
 
 And then execute:
 
-    $ bundle install
+```bash
+bundle install
+```
 
 Or install it yourself as:
 
-    $ gem install technology-icons
+```bash
+gem install technology-icons
+```
 
+### Asset Pipeline Setup
 
-To use this gem add this require statement to your application.css file:
+**For Rails 6.x / 7.x with Sprockets:**
 
-	*= require technology/icons
+Add to your `application.css`:
+
+```css
+*= require technology/icons
+```
+
+**For Rails 7+ with Import Maps:**
+
+Pin and import the stylesheet through your application's asset setup if you copy or expose the gem asset path.
 
 ## Usage
 
-	<em class="icon-flash"></em> Flash
-  	<em class="icon-drupal"></em> Drupal
-  	<a href="#" class="icon-mongodb"></a> MongoDb
+```html
+<em class="icon-flash"></em> Flash
+<em class="icon-drupal"></em> Drupal
+<a href="#" class="icon-mongodb"></a> MongoDb
+```
+
+## Upgrading from 0.x to 1.0
+
+Version 1.0.0 requires Ruby 3.0+ and Rails 6.0+. See [UPGRADE_GUIDE.md](UPGRADE_GUIDE.md) for details.
 
 ## Contributing
 
-
-    1.Fork it
-    2.Create your feature branch (git checkout -b my-new-feature)
-    3.Commit your changes (git commit -am 'Add some feature')
-    4.Push to the branch (git push origin my-new-feature)
-    5.Create new Pull Request
-
+Bug reports and pull requests are welcome on GitHub at https://github.com/ethirajsrinivasan/technology-icons. Contributors are expected to adhere to the [Contributor Covenant](CODE_OF_CONDUCT.md) code of conduct.
 
 ## License
 
-The gem is available as open source under the terms of the [MIT License](http://opensource.org/licenses/MIT).
-
+The gem is available as open source under the terms of the [MIT License](LICENSE.txt).

--- a/Rakefile
+++ b/Rakefile
@@ -1,4 +1,8 @@
+# frozen_string_literal: true
+
 require "bundler/gem_tasks"
 require "rspec/core/rake_task"
-RSpec::Core::RakeTask.new
-task :default => :spec
+
+RSpec::Core::RakeTask.new(:spec)
+
+task default: :spec

--- a/UPGRADE_GUIDE.md
+++ b/UPGRADE_GUIDE.md
@@ -1,0 +1,24 @@
+# Upgrade Guide: Technology-Icons 0.x to 1.0
+
+## Overview
+
+Technology-Icons 1.0 modernizes the gem for current Ruby and Rails versions.
+
+## What Changed
+
+| Component | Old Version | New Version |
+|-----------|-------------|-------------|
+| Ruby | >= 1.9.3 | >= 3.0 |
+| Rails | (implicit) | >= 6.0 |
+
+## Upgrade Steps
+
+1. Ensure your application runs Ruby 3.0+ and Rails 6.0+
+2. Update your Gemfile: `gem 'technology-icons', '~> 1.0'`
+3. Run `bundle update technology-icons`
+4. Verify `*= require technology/icons` still works in your asset pipeline
+
+## Getting Help
+
+- [GitHub Issues](https://github.com/ethirajsrinivasan/technology-icons/issues)
+- [CHANGELOG.md](CHANGELOG.md)

--- a/lib/technology/icons.rb
+++ b/lib/technology/icons.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "technology/icons/version"
 
 module Technology

--- a/lib/technology/icons/version.rb
+++ b/lib/technology/icons/version.rb
@@ -1,5 +1,7 @@
+# frozen_string_literal: true
+
 module Technology
   module Icons
-    VERSION = "0.1.2"
+    VERSION = "1.0.0"
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+require "bundler/setup"
+require "rails"
+require "technology/icons"
+
+RSpec.configure do |config|
+  config.expect_with :rspec do |expectations|
+    expectations.include_chain_clauses_in_custom_matcher_descriptions = true
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "bundler/setup"
+require "logger"
 require "rails"
 require "technology/icons"
 

--- a/spec/technology/icons/version_spec.rb
+++ b/spec/technology/icons/version_spec.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+RSpec.describe Technology::Icons do
+  it "has a version number" do
+    expect(Technology::Icons::VERSION).not_to be_nil
+  end
+
+  it "defines a Rails engine" do
+    expect(Technology::Icons::Engine).to be < Rails::Engine
+  end
+end

--- a/technology-icons.gemspec
+++ b/technology-icons.gemspec
@@ -1,33 +1,43 @@
-# coding: utf-8
-lib = File.expand_path('../lib', __FILE__)
-$LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
-require 'technology/icons/version'
+# frozen_string_literal: true
+
+require_relative "lib/technology/icons/version"
 
 Gem::Specification.new do |spec|
   spec.name          = "technology-icons"
   spec.version       = Technology::Icons::VERSION
-  spec.authors       = ["ethiraj"]
+  spec.authors       = ["ethi"]
   spec.email         = ["ethirajsrinivasan@gmail.com"]
 
-  spec.summary       = "technology-icons is a webfont gem which includes many technology icons to be included in your rails application"
-  spec.description   = "technology-icons is a webfont gem which includes many technology icons to be included in your rails application"
+  spec.summary       = "Technology icon webfont for Rails applications"
+  spec.description   = "A Rails asset gem that packages a technology-icon webfont for use in Rails applications"
   spec.homepage      = "https://github.com/ethirajsrinivasan/technology-icons"
   spec.license       = "MIT"
 
-  # Prevent pushing this gem to RubyGems.org by setting 'allowed_push_host', or
-  # delete this section to allow pushing this gem to any host.
-  if spec.respond_to?(:metadata)
-    spec.metadata['allowed_push_host'] = "https://rubygems.org"
-  else
-    raise "RubyGems 2.0 or newer is required to protect against public gem pushes."
+  spec.metadata = {
+    "allowed_push_host" => "https://rubygems.org",
+    "homepage_uri" => spec.homepage,
+    "source_code_uri" => "https://github.com/ethirajsrinivasan/technology-icons",
+    "bug_tracker_uri" => "https://github.com/ethirajsrinivasan/technology-icons/issues",
+    "changelog_uri" => "https://github.com/ethirajsrinivasan/technology-icons/blob/master/CHANGELOG.md",
+    "documentation_uri" => "https://github.com/ethirajsrinivasan/technology-icons/blob/master/README.md",
+    "rubygems_mfa_required" => "true"
+  }
+
+  spec.files = Dir.chdir(__dir__) do
+    `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
   end
 
-  spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
   spec.bindir        = "exe"
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
-  spec.required_ruby_version = '>= 1.9.3'
-  spec.add_development_dependency "bundler", "~> 1.10"
-  spec.add_development_dependency "rake", "~> 10.0"
-  spec.add_development_dependency 'rspec'
+
+  spec.required_ruby_version = ">= 3.0"
+
+  spec.add_runtime_dependency "railties", ">= 6.0", "< 9.0"
+
+  spec.add_development_dependency "bundler", "~> 2.4"
+  spec.add_development_dependency "bundler-audit", "~> 0.9"
+  spec.add_development_dependency "rake", "~> 13.0"
+  spec.add_development_dependency "rspec", "~> 3.12"
+  spec.add_development_dependency "rubocop", "~> 1.50"
 end

--- a/technology-icons.gemspec
+++ b/technology-icons.gemspec
@@ -35,7 +35,6 @@ Gem::Specification.new do |spec|
 
   spec.add_runtime_dependency "railties", ">= 6.0", "< 9.0"
 
-  spec.add_development_dependency "bundler", "~> 2.4"
   spec.add_development_dependency "bundler-audit", "~> 0.9"
   spec.add_development_dependency "rake", "~> 13.0"
   spec.add_development_dependency "rspec", "~> 3.12"


### PR DESCRIPTION
## Summary
- Modernized for Ruby 3.0+ and Rails 6.0+
- Added CI, RuboCop, specs, and documentation
- Published to RubyGems and validated in the gems-demo Rails app

## Test plan
- [x] CI green on `modernize` branch
- [x] Validated in gems-demo with published gem versions

Made with [Cursor](https://cursor.com)